### PR TITLE
Pomodoro added in utility

### DIFF
--- a/clock.sh
+++ b/clock.sh
@@ -41,6 +41,31 @@ display_help() {
     echo "  -h, --help          Display this help"
 }
 
+draw_pomodoro() {
+    pomodoro_duration=1500  # 25 minutes in seconds
+    short_break_duration=300  # 5 minutes in seconds
+    long_break_duration=900  # 15 minutes in seconds
+    pomodoro_count=0
+
+    while true; do
+        if [ $pomodoro_count -lt 4 ]; then
+            echo -e "\n    \033[1mPomodoro $((pomodoro_count + 1))\033[0m (25 minutes)"
+            draw_timer $pomodoro_duration
+            pomodoro_count=$((pomodoro_count + 1))
+            if [ $pomodoro_count -lt 4 ]; then
+                echo -e "\n    \033[1mShort Break\033[0m (5 minutes)"
+                draw_timer $short_break_duration
+            else
+                echo -e "\n    \033[1mLong Break\033[0m (15 minutes)"
+                draw_timer $long_break_duration
+                pomodoro_count=0
+            fi
+        else
+            pomodoro_count=0
+        fi
+    done
+}
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -c|--clock)
@@ -64,11 +89,16 @@ while [[ "$#" -gt 0 ]]; do
             display_help
             exit 0
             ;;
-        *)
-            echo "Invalid option."
-            display_help
-            exit 1
+        -p|--pomodoro)
+            draw_pomodoro
+            exit 0
             ;;
+        *)
+        echo "Invalid option."
+        display_help
+        exit 1
+        ;;
+            
     esac
     shift
 done


### PR DESCRIPTION
Description:

This pull request adds a Pomodoro timer feature to the utility script, enhancing its functionality. The Pomodoro technique is a time management method that helps users break work into intervals, traditionally 25 minutes in length, separated by short breaks. This implementation offers a seamless way to manage Pomodoro sessions directly from the command line.

Changes:

Introduces the draw_pomodoro function that implements a Pomodoro timer following the 25/5 (work/rest) cycle.
Allows users to start a Pomodoro session using the -p or --pomodoro option.
Integrates the Pomodoro timer seamlessly with existing functionalities for clocks, stopwatches, and timers.
Enhances user experience by providing an additional time management tool within the command line utility.
Usage:

After merging this PR, users can initiate a Pomodoro session by using the -p or --pomodoro option: ./cli_tool.sh -p or ./cli_tool.sh --pomodoro.